### PR TITLE
Check root container for param before return not found error

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -75,11 +75,13 @@ module.exports = function (logger) {
       var parent = _.find(system.topology.containers, function (cont) {
         return cont.id === container.containedBy;
       });
-      if (parent.id === container.id) {
-        return cb(new Error('Cannot find param ' + paramName + ' in ancestors containers'));
-      }
+
       if (parent[paramName]) {
         return cb(null, parent[paramName]);
+      }
+
+      if (parent.id === container.id) {
+        return cb(new Error('Cannot find param ' + paramName + ' in ancestors containers'));
       }
 
       return getParamFromAncestors(parent, paramName, cb);


### PR DESCRIPTION
The code was not taking care of the root container returning
an error without check if the param was present in that node.
