### PR TITLE
Change the name of SQS queue on subscribe

### DIFF
--- a/lib/subscriber.js
+++ b/lib/subscriber.js
@@ -69,7 +69,7 @@ function configSubscriber(config, logger) {
 
               var getSqsQueueUrl = notifications(config, logger).getSqsQueueUrl;
 
-              getSqsQueueUrl(system.name + '-' + system.topology.name, function(err, sqsQueueUrl) {
+              getSqsQueueUrl('nscale-' + system.name + '-' + system.topology.name, function(err, sqsQueueUrl) {
                 if (err) {
                   return cb(); // if there is no queue we just don't subscribe
                 }


### PR DESCRIPTION
When we changed the name of the SQS queue we forgot to
change the name in the subscribe method, this fix the issue
