### PR TITLE
Propagate Name tag

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -140,7 +140,7 @@ module.exports = function (logger) {
       tags = tags.concat([
         {
           Key: 'Name',
-          PropagateAtLaunch: false,
+          PropagateAtLaunch: true,
           Value: container.id
         },
         {


### PR DESCRIPTION
Propagate Name tag so the instances created by that
AutoScalingGroup will have the same name of the AutoScalingGroup
itself
